### PR TITLE
Installer slideshow to set pixmap scaled width

### DIFF
--- a/src-qt5/pc-installgui/InstallerSlideshow.cpp
+++ b/src-qt5/pc-installgui/InstallerSlideshow.cpp
@@ -60,6 +60,11 @@ void Installer::loadSlide(QLabel *textlabel, QLabel *iconlabel, int num){
   }
   //Now apply the item to the label
   textlabel->setText(text);
-  if(iconlabel == 0){ textlabel->setStyleSheet("background-image: "+image); }
-  else{ iconlabel->setPixmap( QPixmap(image) ); }
+  if (iconlabel == 0) {
+    textlabel->setStyleSheet("background-image: "+image);
+  } else {
+    Installer wiz;
+    int width = wiz.geometry().width();
+    iconlabel->setPixmap( QPixmap(image).scaledToWidth(width) );
+  }
 }

--- a/src-qt5/pc-installgui/installer.ui
+++ b/src-qt5/pc-installgui/installer.ui
@@ -1122,7 +1122,7 @@ QFrame{ background: transparent; }
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
                   <horstretch>0</horstretch>
-                  <verstretch>1</verstretch>
+                  <verstretch>0</verstretch>
                  </sizepolicy>
                 </property>
                 <property name="text">


### PR DESCRIPTION
* Gets the installer wizard width and sets pixmap to scaledToWidth
* Removes change to label_slide_icon verstretch, which... doesn't do what I thought it did...

Please inspect these changes closely; C++ noob wondering further into the forest....