### PR TITLE
Make SSH restore work again from the installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ moc_*.cpp
 ui_*.h
 Makefile
 .qmake.stash
+src-qt5/pc-firstbootgui/pc-firstboot
+src-qt5/pc-installgui/pc-sysinstaller
+src-qt5/pc-sysconfig/pc-sysconfig
+src-qt5/pc-xgui/pc-xgui

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.o
+*.*~
+qrc_*.cpp
+moc_*.cpp
+ui_*.h
+Makefile
+.qmake.stash

--- a/src-qt5/pc-installgui/wizardRestore.cpp
+++ b/src-qt5/pc-installgui/wizardRestore.cpp
@@ -97,23 +97,6 @@ void wizardRestore::slotNext(){
   }
 }
 
-int wizardRestore::nextId() const
-{
-  switch (currentId()) {
-     case Page_Host:
-       if (tabRestore->currentIndex() == 0) {
-         return Page_Finish;
-       }
-       break;
-     case Page_Finish:
-       return -1;
-       break;
-     default:
-       return currentId() + 1;
-  }
-  return currentId() + 1;
-}
-
 void wizardRestore::initializePage(int page)
 {
   switch (page) {

--- a/src-qt5/pc-installgui/wizardRestore.cpp
+++ b/src-qt5/pc-installgui/wizardRestore.cpp
@@ -56,20 +56,14 @@ bool wizardRestore::validatePage()
      case Page_Intro:
          button(QWizard::NextButton)->setEnabled(true);
          return true;
-     case Page_Host:
-         // Check if on the SSH restore tab
-         if ( lineHostName->text().isEmpty() ) {
-           button(QWizard::NextButton)->setEnabled(false);
-           return false;
-         }
-         if ( lineUserName->text().isEmpty() ) {
-           button(QWizard::NextButton)->setEnabled(false);
-           return false;
-         }
-
-         // if we get this far, all the fields are filled in
-         button(QWizard::NextButton)->setEnabled(true);
-         return true;
+     case Page_Host: {
+         // Check if on the SSH restore tab has something in it's edit fields.
+         // If it does continue.
+         const bool itemsNotCompleted = lineHostName->text().isEmpty()
+					|| lineUserName->text().isEmpty();
+	  button(QWizard::NextButton)->setDisabled(itemsNotCompleted);
+	  return !itemsNotCompleted;
+     }
      case Page_Auth:
          button(QWizard::NextButton)->setEnabled(true);
          return true;

--- a/src-qt5/pc-installgui/wizardRestore.h
+++ b/src-qt5/pc-installgui/wizardRestore.h
@@ -17,7 +17,6 @@ public:
         }
     void programInit();
     virtual void initializePage(int);
-    virtual int nextId() const;
 
 public slots:
 


### PR DESCRIPTION
This simply re-enables the asking for authentication information for SSH restores in the installer. It seems that when the iSCSI restore was removed, an check based on it was not removed. See the fourth commit for the main stuff (and explaination).